### PR TITLE
fix build

### DIFF
--- a/src/argpass.c
+++ b/src/argpass.c
@@ -6,6 +6,8 @@
 
 #include"argpass.h"
 
+struct arguments arguments;
+
 //argp content
 const char *argp_program_version = "Blezz 0.1";
 const char *argp_program_bug_address = "<mmhmaster@hotmail.com>";

--- a/src/argpass.h
+++ b/src/argpass.h
@@ -19,7 +19,7 @@ struct arguments {
     char *configFile, *contentFile, *font, *startDir;
 };
 
-struct arguments arguments;
+extern struct arguments arguments;
 
 void argumentsInit();
 void argumentsApply(int argc,char** argv);

--- a/src/data.c
+++ b/src/data.c
@@ -13,6 +13,7 @@ Dir** allDirs = NULL;
 Act** allActs = NULL;
 int dirStackTop = -1;
 Dir** dirStack;
+Dir* startDir;
 
 int isDirRef(char* string){
     return strlen(string)>6 && (strncmp(string,"dir(",4) == 0);

--- a/src/data.h
+++ b/src/data.h
@@ -24,15 +24,15 @@ struct Act{
 };
 
 //Shared variables
-int   savedDirs;
-int   savedActs;
-Dir** allDirs;
-Act** allActs;
+extern int   savedDirs;
+extern int   savedActs;
+extern Dir** allDirs;
+extern Act** allActs;
 
-int   dirStackTop;
-Dir** dirStack;
+extern int   dirStackTop;
+extern Dir** dirStack;
 
-Dir* startDir;
+extern Dir* startDir;
 
 //Functions
 int isDirDecl(char* string);

--- a/src/file.c
+++ b/src/file.c
@@ -7,6 +7,9 @@
 #include"argpass.h"
 #include"data.h"
 
+int configLines;
+int contentLines;
+
 char** getLines(FILE* file) {
     int lines_to_allocate = 64;
     int line_size_to_allocate = 100;

--- a/src/file.h
+++ b/src/file.h
@@ -3,8 +3,8 @@
 
 #include<stdio.h>
 
-int configLines;
-int contentLines;
+extern int configLines;
+extern int contentLines;
 
 void importConfig(char* path);
 void importContent(char* path);


### PR DESCRIPTION
you were declaring static variables inside a header and then including that header in multiple source files, that caused a "multiple definition" error preventing me for building the project

<details>
    <summary>Error log</summary>

    gcc -c -g -Wall src/main.c -lxcb -o src/main.o
    gcc -c -g -Wall src/errors.c -lxcb -o src/errors.o
    gcc -c -g -Wall src/data.c -lxcb -o src/data.o
    gcc -c -g -Wall src/file.c -lxcb -o src/file.o
    gcc -c -g -Wall src/gui.c -lxcb -o src/gui.o
    gcc -c -g -Wall src/argpass.c -lxcb -o src/argpass.o
    gcc -c -g -Wall src/keys.c -lxcb -o src/keys.o
    gcc -c -g -Wall src/mutex.c -lxcb -o src/mutex.o
    gcc  ./src/main.o ./src/errors.o ./src/data.o ./src/file.o ./src/gui.o ./src/argpass.o ./src/keys.o ./src/mutex.o -lxcb  -o blezz
    /usr/bin/ld: ./src/data.o:/home/alpheratz/blezz/src/file.h:6: multiple definition of `configLines'; ./src/main.o:/home/alpheratz/blezz/src/file.h:6: first defined here
    /usr/bin/ld: ./src/data.o:/home/alpheratz/blezz/src/file.h:7: multiple definition of `contentLines'; ./src/main.o:/home/alpheratz/blezz/src/file.h:7: first defined here
    /usr/bin/ld: ./src/data.o:/home/alpheratz/blezz/src/data.h:27: multiple definition of `savedDirs'; ./src/main.o:/home/alpheratz/blezz/src/data.h:27: first defined here
    /usr/bin/ld: ./src/data.o:/home/alpheratz/blezz/src/data.h:28: multiple definition of `savedActs'; ./src/main.o:/home/alpheratz/blezz/src/data.h:28: first defined here
    /usr/bin/ld: ./src/data.o:/home/alpheratz/blezz/src/data.h:29: multiple definition of `allDirs'; ./src/main.o:/home/alpheratz/blezz/src/data.h:29: first defined here
    /usr/bin/ld: ./src/data.o:/home/alpheratz/blezz/src/data.h:30: multiple definition of `allActs'; ./src/main.o:/home/alpheratz/blezz/src/data.h:30: first defined here
    /usr/bin/ld: ./src/data.o:/home/alpheratz/blezz/src/data.h:32: multiple definition of `dirStackTop'; ./src/main.o:/home/alpheratz/blezz/src/data.h:32: first defined here
    /usr/bin/ld: ./src/data.o:/home/alpheratz/blezz/src/data.h:33: multiple definition of `dirStack'; ./src/main.o:/home/alpheratz/blezz/src/data.h:33: first defined here
    /usr/bin/ld: ./src/data.o:/home/alpheratz/blezz/src/data.h:35: multiple definition of `startDir'; ./src/main.o:/home/alpheratz/blezz/src/data.h:35: first defined here
    /usr/bin/ld: ./src/data.o:/home/alpheratz/blezz/src/argpass.h:22: multiple definition of `arguments'; ./src/main.o:/home/alpheratz/blezz/src/argpass.h:22: first defined here
    /usr/bin/ld: ./src/file.o:/home/alpheratz/blezz/src/file.h:6: multiple definition of `configLines'; ./src/main.o:/home/alpheratz/blezz/src/file.h:6: first defined here
    /usr/bin/ld: ./src/file.o:/home/alpheratz/blezz/src/file.h:7: multiple definition of `contentLines'; ./src/main.o:/home/alpheratz/blezz/src/file.h:7: first defined here
    /usr/bin/ld: ./src/file.o:/home/alpheratz/blezz/src/argpass.h:22: multiple definition of `arguments'; ./src/main.o:/home/alpheratz/blezz/src/argpass.h:22: first defined here
    /usr/bin/ld: ./src/file.o:/home/alpheratz/blezz/src/data.h:27: multiple definition of `savedDirs'; ./src/main.o:/home/alpheratz/blezz/src/data.h:27: first defined here
    /usr/bin/ld: ./src/file.o:/home/alpheratz/blezz/src/data.h:28: multiple definition of `savedActs'; ./src/main.o:/home/alpheratz/blezz/src/data.h:28: first defined here
    /usr/bin/ld: ./src/file.o:/home/alpheratz/blezz/src/data.h:29: multiple definition of `allDirs'; ./src/main.o:/home/alpheratz/blezz/src/data.h:29: first defined here
    /usr/bin/ld: ./src/file.o:/home/alpheratz/blezz/src/data.h:30: multiple definition of `allActs'; ./src/main.o:/home/alpheratz/blezz/src/data.h:30: first defined here
    /usr/bin/ld: ./src/file.o:/home/alpheratz/blezz/src/data.h:32: multiple definition of `dirStackTop'; ./src/main.o:/home/alpheratz/blezz/src/data.h:32: first defined here
    /usr/bin/ld: ./src/file.o:/home/alpheratz/blezz/src/data.h:33: multiple definition of `dirStack'; ./src/main.o:/home/alpheratz/blezz/src/data.h:33: first defined here
    /usr/bin/ld: ./src/file.o:/home/alpheratz/blezz/src/data.h:35: multiple definition of `startDir'; ./src/main.o:/home/alpheratz/blezz/src/data.h:35: first defined here
    /usr/bin/ld: ./src/gui.o:/home/alpheratz/blezz/src/data.h:27: multiple definition of `savedDirs'; ./src/main.o:/home/alpheratz/blezz/src/data.h:27: first defined here
    /usr/bin/ld: ./src/gui.o:/home/alpheratz/blezz/src/data.h:28: multiple definition of `savedActs'; ./src/main.o:/home/alpheratz/blezz/src/data.h:28: first defined here
    /usr/bin/ld: ./src/gui.o:/home/alpheratz/blezz/src/data.h:29: multiple definition of `allDirs'; ./src/main.o:/home/alpheratz/blezz/src/data.h:29: first defined here
    /usr/bin/ld: ./src/gui.o:/home/alpheratz/blezz/src/data.h:30: multiple definition of `allActs'; ./src/main.o:/home/alpheratz/blezz/src/data.h:30: first defined here
    /usr/bin/ld: ./src/gui.o:/home/alpheratz/blezz/src/data.h:32: multiple definition of `dirStackTop'; ./src/main.o:/home/alpheratz/blezz/src/data.h:32: first defined here
    /usr/bin/ld: ./src/gui.o:/home/alpheratz/blezz/src/data.h:33: multiple definition of `dirStack'; ./src/main.o:/home/alpheratz/blezz/src/data.h:33: first defined here
    /usr/bin/ld: ./src/gui.o:/home/alpheratz/blezz/src/data.h:35: multiple definition of `startDir'; ./src/main.o:/home/alpheratz/blezz/src/data.h:35: first defined here
    /usr/bin/ld: ./src/gui.o:/home/alpheratz/blezz/src/argpass.h:22: multiple definition of `arguments'; ./src/main.o:/home/alpheratz/blezz/src/argpass.h:22: first defined here
    /usr/bin/ld: ./src/argpass.o:/home/alpheratz/blezz/src/argpass.h:22: multiple definition of `arguments'; ./src/main.o:/home/alpheratz/blezz/src/argpass.h:22: first defined here
    collect2: error: ld returned 1 exit status
    make: *** [makefile:13: blezz] Error 1
</details>